### PR TITLE
Add Sayamaike Autumn Festival 2025 event page

### DIFF
--- a/sayamaike_2025.html
+++ b/sayamaike_2025.html
@@ -1,0 +1,1131 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>狭山池 秋の大遊祭 2025 | 走る・食べる・踊る・遊ぶ、全部楽しむ秋の一日</title>
+    <meta name="description" content="2025年11月16日開催！大阪狭山市・狭山池で行われる秋の大型フェスティバル。リレーマラソン、ステージイベント、キッズランド、グルメが楽しめる家族向けイベント。参加費無料。">
+    <meta name="keywords" content="狭山池,大遊祭,リレーマラソン,大阪狭山市,ファミリーイベント,秋祭り,2025年11月16日,キッズランド,グルメフェス">
+    <meta property="og:title" content="狭山池 秋の大遊祭 2025">
+    <meta property="og:description" content="走る・食べる・踊る・遊ぶ、全部楽しむ秋の一日">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://sayamaike-daiyusai.jp">
+    <meta property="og:image" content="https://sayamaike-daiyusai.jp/images/ogp.jpg">
+    <meta name="twitter:card" content="summary_large_image">
+    <!-- Rounded Japanese font for softer impression -->
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap" rel="stylesheet">
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        :root {
+            --primary-orange: #F4A460;
+            --secondary-blue: #4682B4;
+            --accent-red: #CD5C5C;
+            --text-dark: #333;
+            --text-light: #666;
+            --bg-light: #FFF8F0;
+            --autumn-brown: #8B4513;
+        }
+        body {
+            font-family: 'M PLUS Rounded 1c', 'Noto Sans JP', -apple-system, BlinkMacSystemFont, sans-serif;
+            line-height: 1.6;
+            color: var(--text-dark);
+            overflow-x: hidden;
+        }
+        /* ナビゲーション */
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            z-index: 1000;
+            transition: transform 0.3s ease;
+        }
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 15px 20px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .logo {
+            font-size: 1.5rem;
+            font-weight: bold;
+            color: var(--primary-orange);
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .logo::before {
+            content: "🍁";
+            font-size: 1.8rem;
+        }
+        .nav-links {
+            display: flex;
+            gap: 30px;
+            list-style: none;
+        }
+        .nav-links a {
+            text-decoration: none;
+            color: var(--text-dark);
+            font-weight: 500;
+            transition: color 0.3s ease;
+            position: relative;
+        }
+        .nav-links a:hover {
+            color: var(--primary-orange);
+        }
+        .nav-links a::after {
+            content: '';
+            position: absolute;
+            bottom: -5px;
+            left: 0;
+            width: 0;
+            height: 2px;
+            background: var(--primary-orange);
+            transition: width 0.3s ease;
+        }
+        .nav-links a:hover::after {
+            width: 100%;
+        }
+        .cta-button {
+            background: linear-gradient(135deg, var(--primary-orange), var(--accent-red));
+            color: white;
+            padding: 10px 25px;
+            border-radius: 25px;
+            text-decoration: none;
+            font-weight: bold;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .cta-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 20px rgba(244, 164, 96, 0.4);
+        }
+        /* ヒーローセクション */
+        .hero {
+            margin-top: 70px;
+            min-height: 100vh;
+            background: linear-gradient(135deg, var(--bg-light) 0%, #FFE4E1 100%);
+            position: relative;
+            overflow: hidden;
+            display: flex;
+            align-items: center;
+        }
+        .hero::before {
+            content: '';
+            position: absolute;
+            top: -50%;
+            right: -50%;
+            width: 200%;
+            height: 200%;
+            background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y="50" font-size="80" opacity="0.1">🍂</text></svg>') repeat;
+            animation: float 20s linear infinite;
+        }
+        @keyframes float {
+            0% { transform: translate(0, 0) rotate(0deg); }
+            100% { transform: translate(-100px, 100px) rotate(360deg); }
+        }
+        .hero-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 40px 20px;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 50px;
+            align-items: center;
+            position: relative;
+            z-index: 1;
+        }
+        .hero-content h1 {
+            font-size: 3.5rem;
+            line-height: 1.2;
+            margin-bottom: 20px;
+            background: linear-gradient(135deg, var(--primary-orange), var(--accent-red));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            animation: fadeInUp 1s ease;
+        }
+        .hero-content .subtitle {
+            font-size: 1.5rem;
+            color: var(--text-light);
+            margin-bottom: 30px;
+            animation: fadeInUp 1s ease 0.2s both;
+        }
+        .event-date {
+            display: inline-block;
+            background: white;
+            padding: 15px 30px;
+            border-radius: 30px;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+            margin-bottom: 30px;
+            animation: fadeInUp 1s ease 0.4s both;
+        }
+        .event-date strong {
+            color: var(--primary-orange);
+            font-size: 1.2rem;
+        }
+        .hero-buttons {
+            display: flex;
+            gap: 20px;
+            animation: fadeInUp 1s ease 0.6s both;
+        }
+        .btn-primary {
+            background: linear-gradient(135deg, var(--primary-orange), var(--accent-red));
+            color: white;
+            padding: 15px 40px;
+            border-radius: 30px;
+            text-decoration: none;
+            font-weight: bold;
+            font-size: 1.1rem;
+            transition: all 0.3s ease;
+            display: inline-block;
+        }
+        .btn-primary:hover {
+            transform: translateY(-3px);
+            box-shadow: 0 10px 30px rgba(244, 164, 96, 0.4);
+        }
+        .btn-secondary {
+            background: white;
+            color: var(--primary-orange);
+            padding: 15px 40px;
+            border-radius: 30px;
+            text-decoration: none;
+            font-weight: bold;
+            font-size: 1.1rem;
+            border: 2px solid var(--primary-orange);
+            transition: all 0.3s ease;
+            display: inline-block;
+        }
+        .btn-secondary:hover {
+            background: var(--primary-orange);
+            color: white;
+            transform: translateY(-3px);
+        }
+        .hero-image {
+            position: relative;
+            animation: float-image 3s ease-in-out infinite;
+        }
+        @keyframes float-image {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-20px); }
+        }
+        .hero-icons {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 20px;
+        }
+        .icon-card {
+            background: white;
+            padding: 25px;
+            border-radius: 20px;
+            text-align: center;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+            transition: transform 0.3s ease;
+        }
+        .icon-card:hover {
+            transform: translateY(-5px);
+        }
+        .icon-card .icon {
+            font-size: 3rem;
+            margin-bottom: 10px;
+        }
+        .icon-card h3 {
+            color: var(--text-dark);
+            font-size: 1.1rem;
+        }
+        /* イベント概要セクション */
+        .about-section {
+            padding: 100px 20px;
+            background: white;
+        }
+        .section-container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        .section-title {
+            text-align: center;
+            font-size: 2.5rem;
+            margin-bottom: 20px;
+            color: var(--text-dark);
+            position: relative;
+        }
+        .section-title::after {
+            content: '';
+            position: absolute;
+            bottom: -10px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 80px;
+            height: 3px;
+            background: linear-gradient(135deg, var(--primary-orange), var(--accent-red));
+        }
+        .section-subtitle {
+            text-align: center;
+            color: var(--text-light);
+            margin-bottom: 50px;
+            font-size: 1.1rem;
+        }
+        .features-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 40px;
+            margin-top: 60px;
+        }
+        .feature-card {
+            background: var(--bg-light);
+            padding: 40px;
+            border-radius: 20px;
+            text-align: center;
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+        .feature-card:hover {
+            transform: translateY(-10px);
+            box-shadow: 0 15px 40px rgba(0,0,0,0.1);
+        }
+        .feature-icon {
+            width: 80px;
+            height: 80px;
+            margin: 0 auto 20px;
+            background: linear-gradient(135deg, var(--primary-orange), var(--accent-red));
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 2.5rem;
+        }
+        .feature-card h3 {
+            margin-bottom: 15px;
+            color: var(--text-dark);
+            font-size: 1.5rem;
+        }
+        .feature-card p {
+            color: var(--text-light);
+            line-height: 1.8;
+        }
+        /* コンテンツセクション */
+        .contents-section {
+            padding: 100px 20px;
+            background: linear-gradient(135deg, #FFF8F0 0%, #FFE4E1 100%);
+        }
+        .content-cards {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 30px;
+            margin-top: 50px;
+        }
+        .content-card {
+            background: white;
+            border-radius: 20px;
+            overflow: hidden;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+            transition: transform 0.3s ease;
+            cursor: pointer;
+        }
+        .content-card:hover {
+            transform: translateY(-10px) scale(1.02);
+        }
+        .content-card-header {
+            padding: 40px 30px;
+            background: linear-gradient(135deg, var(--primary-orange), var(--accent-red));
+            color: white;
+            text-align: center;
+        }
+        .content-card-header .emoji {
+            font-size: 3rem;
+            margin-bottom: 10px;
+        }
+        .content-card-header h3 {
+            font-size: 1.5rem;
+        }
+        .content-card-body {
+            padding: 30px;
+        }
+        .content-card-body ul {
+            list-style: none;
+        }
+        .content-card-body li {
+            padding: 10px 0;
+            border-bottom: 1px solid #eee;
+            color: var(--text-light);
+        }
+        .content-card-body li:last-child {
+            border-bottom: none;
+        }
+        .content-card-body li::before {
+            content: "✓ ";
+            color: var(--primary-orange);
+            font-weight: bold;
+            margin-right: 10px;
+        }
+        /* タイムスケジュール */
+        .schedule-section {
+            padding: 100px 20px;
+            background: white;
+        }
+        .timeline {
+            max-width: 800px;
+            margin: 50px auto;
+            position: relative;
+        }
+        .timeline::before {
+            content: '';
+            position: absolute;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 2px;
+            height: 100%;
+            background: var(--primary-orange);
+        }
+        .timeline-item {
+            position: relative;
+            padding: 20px 0;
+        }
+        .timeline-item:nth-child(odd) .timeline-content {
+            margin-right: 55%;
+            text-align: right;
+        }
+        .timeline-item:nth-child(even) .timeline-content {
+            margin-left: 55%;
+        }
+        .timeline-content {
+            background: var(--bg-light);
+            padding: 20px;
+            border-radius: 15px;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+        }
+        .timeline-time {
+            font-weight: bold;
+            color: var(--primary-orange);
+            font-size: 1.2rem;
+            margin-bottom: 10px;
+        }
+        .timeline-title {
+            font-size: 1.1rem;
+            color: var(--text-dark);
+            margin-bottom: 5px;
+        }
+        .timeline-desc {
+            color: var(--text-light);
+            font-size: 0.9rem;
+        }
+        .timeline-dot {
+            position: absolute;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 20px;
+            height: 20px;
+            background: var(--primary-orange);
+            border-radius: 50%;
+            border: 4px solid white;
+            box-shadow: 0 0 0 3px var(--primary-orange);
+        }
+        /* スポンサーセクション */
+        .sponsor-section {
+            padding: 100px 20px;
+            background: linear-gradient(135deg, #FFF8F0 0%, #FFE4E1 100%);
+        }
+        .sponsor-benefits {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 30px;
+            margin: 50px 0;
+        }
+        .benefit-card {
+            background: white;
+            padding: 30px;
+            border-radius: 15px;
+            text-align: center;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+        }
+        .benefit-card .icon {
+            font-size: 3rem;
+            margin-bottom: 15px;
+        }
+        .benefit-card h4 {
+            color: var(--text-dark);
+            margin-bottom: 10px;
+        }
+        .benefit-card p {
+            color: var(--text-light);
+            font-size: 0.95rem;
+        }
+        .sponsor-list {
+            max-width: 900px;
+            margin: 0 auto 50px;
+        }
+        .sponsor-list h3 {
+            text-align: center;
+            font-size: 2rem;
+            color: var(--text-dark);
+            margin-bottom: 30px;
+        }
+        .sponsor-logos {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 20px;
+            align-items: center;
+            justify-items: center;
+        }
+        .sponsor-logo {
+            background: white;
+            padding: 20px;
+            border-radius: 15px;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+            font-weight: 500;
+            color: var(--text-light);
+        }
+        .sponsor-cta {
+            text-align: center;
+            margin-top: 50px;
+            padding: 40px;
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+        }
+        .sponsor-cta h3 {
+            font-size: 2rem;
+            color: var(--text-dark);
+            margin-bottom: 20px;
+        }
+        .sponsor-cta p {
+            color: var(--text-light);
+            margin-bottom: 30px;
+            font-size: 1.1rem;
+        }
+        /* アクセス */
+        .access-section {
+            padding: 100px 20px;
+            background: white;
+        }
+        .access-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 50px;
+            margin-top: 50px;
+        }
+        .access-info {
+            padding: 30px;
+        }
+        .access-info h3 {
+            color: var(--text-dark);
+            margin-bottom: 20px;
+            font-size: 1.5rem;
+        }
+        .access-item {
+            margin-bottom: 20px;
+            padding: 15px;
+            background: var(--bg-light);
+            border-radius: 10px;
+        }
+        .access-item strong {
+            color: var(--primary-orange);
+            display: block;
+            margin-bottom: 5px;
+        }
+        .map-container {
+            background: #ddd;
+            border-radius: 20px;
+            height: 400px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--text-light);
+            font-size: 1.2rem;
+        }
+        /* FAQ */
+        .faq-section {
+            padding: 100px 20px;
+            background: var(--bg-light);
+        }
+        .faq-container {
+            max-width: 800px;
+            margin: 50px auto;
+        }
+        .faq-item {
+            background: white;
+            margin-bottom: 20px;
+            border-radius: 15px;
+            overflow: hidden;
+            box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+        }
+        .faq-question {
+            padding: 25px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            transition: background 0.3s ease;
+        }
+        .faq-question:hover {
+            background: var(--bg-light);
+        }
+        .faq-question h4 {
+            color: var(--text-dark);
+            font-size: 1.1rem;
+        }
+        .faq-icon {
+            font-size: 1.5rem;
+            color: var(--primary-orange);
+            transition: transform 0.3s ease;
+        }
+        .faq-item.active .faq-icon {
+            transform: rotate(45deg);
+        }
+        .faq-answer {
+            padding: 0 25px;
+            max-height: 0;
+            overflow: hidden;
+            transition: max-height 0.3s ease, padding 0.3s ease;
+        }
+        .faq-item.active .faq-answer {
+            padding: 0 25px 25px;
+            max-height: 300px;
+        }
+        /* フッター */
+        footer {
+            background: var(--text-dark);
+            color: white;
+            padding: 50px 20px 30px;
+        }
+        .footer-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 40px;
+            margin-bottom: 30px;
+        }
+        .footer-section h4 {
+            margin-bottom: 20px;
+            color: var(--primary-orange);
+        }
+        .footer-section p, .footer-section a {
+            color: #ccc;
+            text-decoration: none;
+            line-height: 1.8;
+        }
+        .footer-section a:hover {
+            color: var(--primary-orange);
+        }
+        .footer-section ul {
+            list-style: none;
+        }
+        .footer-section li {
+            margin-bottom: 10px;
+        }
+        .social-links {
+            display: flex;
+            gap: 15px;
+            margin-top: 20px;
+        }
+        .social-links a {
+            width: 40px;
+            height: 40px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background 0.3s ease;
+        }
+        .social-links a:hover {
+            background: var(--primary-orange);
+        }
+        .footer-bottom {
+            text-align: center;
+            padding-top: 30px;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            color: #999;
+        }
+        /* アニメーション */
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translateY(30px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+        /* レスポンシブ */
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+            }
+            .hero-container {
+                grid-template-columns: 1fr;
+            }
+            .hero-content h1 {
+                font-size: 2.5rem;
+            }
+            .hero-buttons {
+                flex-direction: column;
+            }
+            .access-grid {
+                grid-template-columns: 1fr;
+            }
+            .timeline::before {
+                left: 30px;
+            }
+            .timeline-item .timeline-content {
+                margin-left: 70px !important;
+                margin-right: 0 !important;
+                text-align: left !important;
+            }
+            .timeline-dot {
+                left: 30px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- ナビゲーション -->
+    <nav id="navbar">
+        <div class="nav-container">
+            <a href="#" class="logo">狭山池 秋の大遊祭</a>
+            <ul class="nav-links">
+                <li><a href="#about">イベント概要</a></li>
+                <li><a href="#contents">コンテンツ</a></li>
+                <li><a href="#schedule">スケジュール</a></li>
+                <li><a href="#access">アクセス</a></li>
+                <li><a href="#sponsor">スポンサー</a></li>
+            </ul>
+            <a href="#entry" class="cta-button">参加申込</a>
+        </div>
+    </nav>
+    <!-- ヒーローセクション -->
+    <section class="hero">
+        <div class="hero-container">
+            <div class="hero-content">
+                <h1>狭山池<br>秋の大遊祭</h1>
+                <p class="subtitle">走る・食べる・踊る・遊ぶ、全部楽しむ秋の一日</p>
+                <div class="event-date">
+                    <strong>2025年11月16日(日)</strong> 11:00〜20:30
+                </div>
+                <div class="hero-buttons">
+                    <a href="#entry" class="btn-primary">イベントに参加する</a>
+                    <a href="#sponsor" class="btn-secondary">スポンサーになる</a>
+                </div>
+            </div>
+            <div class="hero-image">
+                <div class="hero-icons">
+                    <div class="icon-card">
+                        <div class="icon">🏃</div>
+                        <h3>リレーマラソン</h3>
+                    </div>
+                    <div class="icon-card">
+                        <div class="icon">🎪</div>
+                        <h3>キッズランド</h3>
+                    </div>
+                    <div class="icon-card">
+                        <div class="icon">🎤</div>
+                        <h3>ステージ</h3>
+                    </div>
+                    <div class="icon-card">
+                        <div class="icon">🍔</div>
+                        <h3>グルメ</h3>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- イベント概要 -->
+    <section id="about" class="about-section">
+        <div class="section-container">
+            <h2 class="section-title">イベント概要</h2>
+            <p class="section-subtitle">日本最古のダム式ため池「狭山池」を舞台にした市民フェスティバル</p>
+            <div class="features-grid">
+                <div class="feature-card">
+                    <div class="feature-icon">🏛️</div>
+                    <h3>歴史ある会場</h3>
+                    <p>1400年の歴史を持つ狭山池を舞台に、自然と歴史を感じながら楽しめる特別な一日</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">👨‍👩‍👧‍👦</div>
+                    <h3>全世代が楽しめる</h3>
+                    <p>子どもから大人まで、スポーツ・音楽・食・遊びを通じて幅広い世代が交流できるイベント</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🎉</div>
+                    <h3>入場無料</h3>
+                    <p>どなたでも気軽に参加可能。一部有料コンテンツもリーズナブルな価格設定</p>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- コンテンツ -->
+    <section id="contents" class="contents-section">
+        <div class="section-container">
+            <h2 class="section-title">イベントコンテンツ</h2>
+            <p class="section-subtitle">一日中楽しめる多彩なプログラム</p>
+            <div class="content-cards">
+                <div class="content-card">
+                    <div class="content-card-header">
+                        <div class="emoji">🏃‍♂️</div>
+                        <h3>リレーマラソン</h3>
+                    </div>
+                    <div class="content-card-body">
+                        <ul>
+                            <li>制限時間2時間</li>
+                            <li>1周約1kmの周回コース</li>
+                            <li>一般・ファミリー・企業の部</li>
+                            <li>参加費：3,000円〜</li>
+                            <li>各部門上位チーム表彰</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="content-card">
+                    <div class="content-card-header">
+                        <div class="emoji">🎪</div>
+                        <h3>キッズランド</h3>
+                    </div>
+                    <div class="content-card-body">
+                        <ul>
+                            <li>巨大ふわふわエリア</li>
+                            <li>大型滑り台</li>
+                            <li>11:00〜18:00開催</li>
+                            <li>安全管理スタッフ常駐</li>
+                            <li>年齢別エリア設置</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="content-card">
+                    <div class="content-card-header">
+                        <div class="emoji">🎤</div>
+                        <h3>ステージイベント</h3>
+                    </div>
+                    <div class="content-card-body">
+                        <ul>
+                            <li>芸能人・歌手ライブ</li>
+                            <li>地域団体パフォーマンス</li>
+                            <li>18:30〜20:30</li>
+                            <li>観覧無料</li>
+                            <li>夜間ライトアップ</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="content-card">
+                    <div class="content-card-header">
+                        <div class="emoji">🎯</div>
+                        <h3>ビンゴ大会</h3>
+                    </div>
+                    <div class="content-card-body">
+                        <ul>
+                            <li>豪華景品多数</li>
+                            <li>参加費500円/枚</li>
+                            <li>地元企業協賛賞品</li>
+                            <li>全世代参加可能</li>
+                            <li>複数回開催</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="content-card">
+                    <div class="content-card-header">
+                        <div class="emoji">🍔</div>
+                        <h3>キッチンカー</h3>
+                    </div>
+                    <div class="content-card-body">
+                        <ul>
+                            <li>約14店舗出店</li>
+                            <li>地域グルメ</li>
+                            <li>11:00〜20:30営業</li>
+                            <li>アルコール販売あり</li>
+                            <li>キッズメニュー充実</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- タイムスケジュール -->
+    <section id="schedule" class="schedule-section">
+        <div class="section-container">
+            <h2 class="section-title">タイムスケジュール</h2>
+            <p class="section-subtitle">イベント当日の流れ</p>
+            <div class="timeline">
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-time">11:00</div>
+                        <div class="timeline-title">開場・受付開始</div>
+                        <div class="timeline-desc">キッズランド・キッチンカーオープン</div>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-time">12:00</div>
+                        <div class="timeline-title">リレーマラソン スタート</div>
+                        <div class="timeline-desc">制限時間2時間の熱戦開始</div>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-time">14:00</div>
+                        <div class="timeline-title">リレーマラソン 終了</div>
+                        <div class="timeline-desc">競技終了</div>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-time">14:30</div>
+                        <div class="timeline-title">表彰式</div>
+                        <div class="timeline-desc">各部門上位チーム表彰</div>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-time">15:00</div>
+                        <div class="timeline-title">ビンゴ大会</div>
+                        <div class="timeline-desc">豪華景品をゲット！</div>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-time">18:30</div>
+                        <div class="timeline-title">ステージイベント</div>
+                        <div class="timeline-desc">音楽ライブ・パフォーマンス</div>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <div class="timeline-time">20:30</div>
+                        <div class="timeline-title">閉場</div>
+                        <div class="timeline-desc">また来年お会いしましょう！</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- スポンサー募集 -->
+    <section id="sponsor" class="sponsor-section">
+        <div class="section-container">
+            <h2 class="section-title">スポンサー募集</h2>
+            <p class="section-subtitle">地域活性化にご協力ください</p>
+            <div class="sponsor-benefits">
+                <div class="benefit-card">
+                    <div class="icon">📢</div>
+                    <h4>広告効果</h4>
+                    <p>約1,500人の来場者に向けて企業PRが可能</p>
+                </div>
+                <div class="benefit-card">
+                    <div class="icon">🤝</div>
+                    <h4>地域貢献</h4>
+                    <p>地域イベントへの協力で企業イメージアップ</p>
+                </div>
+                <div class="benefit-card">
+                    <div class="icon">🎪</div>
+                    <h4>ブース出展</h4>
+                    <p>PRブースの設置で直接的な顧客接点を創出</p>
+                </div>
+                <div class="benefit-card">
+                    <div class="icon">📱</div>
+                    <h4>SNS露出</h4>
+                    <p>公式SNSでの企業名掲載・拡散</p>
+                </div>
+            </div>
+            <div class="sponsor-list">
+                <h3>協賛企業</h3>
+                <div class="sponsor-logos">
+                    <div class="sponsor-logo">スポンサーA</div>
+                    <div class="sponsor-logo">スポンサーB</div>
+                    <div class="sponsor-logo">スポンサーC</div>
+                    <div class="sponsor-logo">スポンサーD</div>
+                </div>
+            </div>
+            <div class="sponsor-cta">
+                <h3>スポンサーとして参加しませんか？</h3>
+                <p>詳細な資料をご用意しております。お気軽にお問い合わせください。</p>
+                <a href="mailto:sayamaike_daiyuusai@googlegroups.com" class="btn-primary">スポンサー資料を請求</a>
+            </div>
+        </div>
+    </section>
+    <!-- アクセス -->
+    <section id="access" class="access-section">
+        <div class="section-container">
+            <h2 class="section-title">アクセス</h2>
+            <p class="section-subtitle">会場へのアクセス方法</p>
+            <div class="access-grid">
+                <div class="access-info">
+                    <h3>狭山池</h3>
+                    <div class="access-item">
+                        <strong>住所</strong>
+                        大阪府大阪狭山市岩室
+                    </div>
+                    <div class="access-item">
+                        <strong>電車でお越しの方</strong>
+                        南海高野線「大阪狭山市駅」より徒歩10分
+                    </div>
+                    <div class="access-item">
+                        <strong>お車でお越しの方</strong>
+                        会場周辺に有料駐車場あり（台数限定）<br>
+                        公共交通機関のご利用を推奨します
+                    </div>
+                    <div class="access-item">
+                        <strong>注意事項</strong>
+                        会場周辺の路上駐車は固くお断りします
+                    </div>
+                </div>
+                <div class="map-container">
+                    地図を表示
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- FAQ -->
+    <section class="faq-section">
+        <div class="section-container">
+            <h2 class="section-title">よくある質問</h2>
+            <p class="section-subtitle">お問い合わせの多い質問をまとめました</p>
+            <div class="faq-container">
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h4>Q. 雨天の場合は開催されますか？</h4>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>小雨決行ですが、暴風警報・大雨警報が発令された場合は中止となります。中止の場合は当日朝7時までに公式サイトでお知らせします。</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h4>Q. リレーマラソンの参加条件はありますか？</h4>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>健康な方であれば年齢制限はありません。ファミリーの部は小学生以上のお子様を含むチームでご参加ください。</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h4>Q. 飲食の持ち込みは可能ですか？</h4>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>持ち込みは可能ですが、会場内にはキッチンカーが多数出店予定です。ぜひ地域のグルメもお楽しみください。</p>
+                    </div>
+                </div>
+                <div class="faq-item">
+                    <div class="faq-question">
+                        <h4>Q. ペットの同伴は可能ですか？</h4>
+                        <span class="faq-icon">+</span>
+                    </div>
+                    <div class="faq-answer">
+                        <p>リード着用の上、飼い主様の責任において同伴可能です。ただし、一部エリア（キッズランド等）は入場制限があります。</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <!-- フッター -->
+    <footer>
+        <div class="footer-container">
+            <div class="footer-section">
+                <h4>イベント情報</h4>
+                <p>狭山池 秋の大遊祭</p>
+                <p>2025年11月16日(日)</p>
+                <p>11:00〜20:30</p>
+                <p>大阪府大阪狭山市 狭山池</p>
+            </div>
+            <div class="footer-section">
+                <h4>主催</h4>
+                <ul>
+                    <li>株式会社クリークフォレスト</li>
+                    <li>RETRIN株式会社</li>
+                    <li>南海フードシステム株式会社</li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>お問い合わせ</h4>
+                <p>SAYAMAIKE大遊祭実行委員</p>
+                <p>Email: sayamaike_daiyuusai@googlegroups.com</p>
+                <div class="social-links">
+                    <a href="#">📘</a>
+                    <a href="#">📷</a>
+                    <a href="#">🐦</a>
+                </div>
+            </div>
+            <div class="footer-section">
+                <h4>後援</h4>
+                <p>大阪狭山市役所</p>
+                <h4 style="margin-top: 20px;">協力</h4>
+                <p>トライト株式会社</p>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2025 狭山池 秋の大遊祭 実行委員会. All rights reserved.</p>
+        </div>
+    </footer>
+    <script>
+        // スムーススクロール
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function (e) {
+                e.preventDefault();
+                const target = document.querySelector(this.getAttribute('href'));
+                if (target) {
+                    target.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start'
+                    });
+                }
+            });
+        });
+        // FAQアコーディオン
+        document.querySelectorAll('.faq-question').forEach(question => {
+            question.addEventListener('click', () => {
+                const item = question.parentElement;
+                item.classList.toggle('active');
+                document.querySelectorAll('.faq-item').forEach(otherItem => {
+                    if (otherItem !== item && otherItem.classList.contains('active')) {
+                        otherItem.classList.remove('active');
+                    }
+                });
+            });
+        });
+        // スクロール時のナビゲーション表示制御
+        let lastScroll = 0;
+        window.addEventListener('scroll', () => {
+            const navbar = document.getElementById('navbar');
+            const currentScroll = window.pageYOffset;
+            if (currentScroll <= 0) {
+                navbar.style.transform = 'translateY(0)';
+                return;
+            }
+            if (currentScroll > lastScroll && currentScroll > 100) {
+                navbar.style.transform = 'translateY(-100%)';
+            } else {
+                navbar.style.transform = 'translateY(0)';
+            }
+            lastScroll = currentScroll;
+        });
+        // スクロールアニメーション
+        const observerOptions = {
+            threshold: 0.1,
+            rootMargin: '0px 0px -50px 0px'
+        };
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.style.animation = 'fadeInUp 0.6s ease forwards';
+                }
+            });
+        }, observerOptions);
+        document.querySelectorAll('.feature-card, .content-card, .benefit-card, .timeline-item, .sponsor-logo').forEach(el => {
+            observer.observe(el);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add event page for "狭山池 秋の大遊祭 2025" with rounded Japanese font for softer look
- include sponsor showcase grid so recruited sponsors can be listed

## Testing
- `node main.js` *(fails: ReferenceError: document is not defined)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c836991554832cb9e94991fef3923c